### PR TITLE
Add support for 0 value in output_id.

### DIFF
--- a/gxformat2/export.py
+++ b/gxformat2/export.py
@@ -214,7 +214,7 @@ def _convert_post_job_actions(from_native_step, to_format2_step):
 
 
 def _to_source(has_output_name, label_map, output_id=None):
-    output_id = output_id or has_output_name['id']
+    output_id = output_id if output_id is not None else has_output_name['id']
     output_id = str(output_id)
     output_name = has_output_name['output_name']
     output_label = label_map.get(output_id) or output_id


### PR DESCRIPTION
When importing a packed workflow, output_id can be set to 0,
which causes the exception below:

```
Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 283, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/galaxy/api/workflows.py", line 552, in update
    **from_dict_kwds
  File "lib/galaxy/managers/workflows.py", line 425, in update_workflow_from_raw_description
    self._sync_stored_workflow(trans, stored_workflow)
  File "lib/galaxy/managers/workflows.py", line 540, in _sync_stored_workflow
    wf_dict = from_galaxy_native(wf_dict, None, json_wrapper=True)
  File "/home/jra001k/snapshot/galaxy/.venv/local/lib/python2.7/site-packages/gxformat2/export.py", line 48, in from_galaxy_native
    source = _to_source(workflow_output, label_map, output_id=step["id"])
  File "/home/jra001k/snapshot/galaxy/.venv/local/lib/python2.7/site-packages/gxformat2/export.py", line 217, in _to_source
    output_id = output_id or has_output_name['id']
KeyError: 'id'
```

This is because 'or' operator interprets 0 value as false.

This commit makes _to_source() function handle 0 value as
a regular id.